### PR TITLE
:bug: Fix Tag Bytesize Calculation

### DIFF
--- a/lib/zatca/tag.rb
+++ b/lib/zatca/tag.rb
@@ -24,7 +24,7 @@ module ZATCA
       # TLV should be concatenated together without any separator in the following
       # format: character_value_of_id character_value_of_value_length value_itself
       # All of this should be in 8-bit ASCII.
-      tlv = @id.chr + @value.length.chr + value
+      tlv = @id.chr + @value.bytesize.chr + value
 
       # We need to use force_encoding because encode will raise errors when
       # trying to encode a string with utf-8 characters.

--- a/spec/fixtures/tags.rb
+++ b/spec/fixtures/tags.rb
@@ -6,7 +6,6 @@ FIXTURES_TAGS = {
   invoice_total: "115"
 }.freeze
 
-
 FIXTURES_UNICODE_TAGS = {
   seller_name: "مرسول",
   vat_registration_number: "310228833400003",

--- a/spec/fixtures/tags.rb
+++ b/spec/fixtures/tags.rb
@@ -5,3 +5,12 @@ FIXTURES_TAGS = {
   vat_total: "15",
   invoice_total: "115"
 }.freeze
+
+
+FIXTURES_UNICODE_TAGS = {
+  seller_name: "مرسول",
+  vat_registration_number: "310228833400003",
+  timestamp: "2021-10-20T19:29:32+03:00",
+  vat_total: "15",
+  invoice_total: "115"
+}.freeze

--- a/spec/lib/zatca/tag_spec.rb
+++ b/spec/lib/zatca/tag_spec.rb
@@ -36,7 +36,7 @@ describe ZATCA::Tag do
     end
 
     it "generates a valid TLV when passed unicode input" do
-      expected_output = "\x01\x05\xD9\x85\xD8\xB1\xD8\xB3\xD9\x88\xD9\x84".force_encoding("ASCII-8BIT")
+      expected_output = "\x01\n\xD9\x85\xD8\xB1\xD8\xB3\xD9\x88\xD9\x84".force_encoding("ASCII-8BIT")
 
       expect(unicode_tag.to_tlv).to eq(expected_output)
     end

--- a/spec/lib/zatca/tags_spec.rb
+++ b/spec/lib/zatca/tags_spec.rb
@@ -1,9 +1,14 @@
 describe ZATCA::Tags do
   let(:tags) { ZATCA::Tags.new(FIXTURES_TAGS) }
+  let(:unicode_tags) { ZATCA::Tags.new(FIXTURES_UNICODE_TAGS) }
 
   describe "#to_base64" do
-    it "generates valid Base64" do
+    it "generates valid Base64 with ASCII tags" do
       expect(tags.to_base64).to eq("AQZNcnNvb2wCDzMxMDIyODgzMzQwMDAwMwMZMjAyMS0xMC0yMFQxOToyOTozMiswMzowMAQDMTE1BQIxNQ==")
+    end
+
+    it "generates valid Base64 with unicode tags" do
+      expect(unicode_tags.to_base64).to eq("AQrZhdix2LPZiNmEAg8zMTAyMjg4MzM0MDAwMDMDGTIwMjEtMTAtMjBUMTk6Mjk6MzIrMDM6MDAEAzExNQUCMTU=")
     end
   end
 end


### PR DESCRIPTION
String length was only working for ASCII strings, bytesize works for Unicode which is what ZATCA is expecting.
