### PR TITLE
x509 certificate signature and public key extraction

### DIFF
--- a/lib/zatca/signing/certificate.rb
+++ b/lib/zatca/signing/certificate.rb
@@ -63,14 +63,9 @@ class ZATCA::Signing::Certificate
     parse_signature
   end
 
-  # We'll disable the rule on endless ranges because they are not supported in
-  # older Ruby versions
-  # rubocop:disable Style/SlicingWithRange
   def parse_public_key_bytes
-    # We call public_key twice to get the EC Point from the certificate
-    public_key = openssl_certificate.public_key.to_der
+    openssl_certificate.public_key.to_der
   end
-  # rubocop:enable Style/SlicingWithRange
 
   def parse_signature
     der = openssl_certificate.to_der

--- a/lib/zatca/signing/certificate.rb
+++ b/lib/zatca/signing/certificate.rb
@@ -1,7 +1,7 @@
 class ZATCA::Signing::Certificate
   attr_accessor :serial_number, :issuer_name, :cert_content_without_headers,
     :hash, :public_key, :public_key_without_headers, :signature,
-    :public_key_bytes, :unpacked_signature, :signature_bytes
+    :public_key_bytes
 
   # Returns the certificate hashed with SHA256 then Base64 encoded
   def self.generate_base64_hash(base64_certificate)
@@ -26,7 +26,6 @@ class ZATCA::Signing::Certificate
     @public_key_without_headers = nil
     @public_key_bytes = nil
     @signature = nil
-    @unpacked_signature = nil
 
     @openssl_certificate = openssl_certificate
 
@@ -69,21 +68,7 @@ class ZATCA::Signing::Certificate
   # rubocop:disable Style/SlicingWithRange
   def parse_public_key_bytes
     # We call public_key twice to get the EC Point from the certificate
-    public_key = openssl_certificate.public_key.public_key
-
-    raise "Public key is not an EC Point." unless public_key.is_a?(OpenSSL::PKey::EC::Point)
-
-    bn = OpenSSL::BN.new(public_key.to_bn.to_s(2)[1..-1], 2) # skip first byte (04)
-    ecdsa_public_key = [bn.to_s(16)].pack("H*")
-
-    # Ensure public_key is 64 bytes long
-    if ecdsa_public_key.bytesize < 64
-      "\x00" * (64 - ecdsa_public_key.bytesize) + ecdsa_public_key
-    elsif ecdsa_public_key.bytesize > 64
-      ecdsa_public_key[-64..-1]
-    else
-      ecdsa_public_key
-    end
+    public_key = openssl_certificate.public_key.to_der
   end
   # rubocop:enable Style/SlicingWithRange
 
@@ -95,17 +80,5 @@ class ZATCA::Signing::Certificate
     # The signature would look like so:
     # "0F\x02!\x00\xEEa\xD3\xEB(<\xE6;P\x19jw3\xBBOO\xB2d\xDB\xEC\xEC\xBDQ\xC6\xB3v\xD4\xE5\x9E\xD8\x13\xAF\x02!\x00\xFA\xD1\xE6\xD0jf#b\xF7^nqc5\xFCx_\x87h\xA7\xB2\xEC\x10\x11B5+\vcB\x05i"
     @signature = asn1.value[-1].value
-
-    # Unpack the signature and convert it to hex, then add colons between each byte
-    # So it ends up looking like so:
-    # "30:46:02:21:00:ee:61:d3:eb:28:3c:e6:3b:50:19:6a:77:33:bb:4f:4f:b2:64:db:ec:ec:bd:51:c6:b3:76:d4:e5:9e:d8:13:af:02:21:00:fa:d1:e6:d0:6a:66:23:62:f7:5e:6e:71:63:35:fc:78:5f:87:68:a7:b2:ec:10:11:42:35:2b:0b:63:42:05:69"
-    @unpacked_signature = @signature.unpack1("H*").gsub(/(..)/, '\1:')[0..-2]
-
-    signature_asn1 = OpenSSL::ASN1.decode(asn1.value.last.value)
-    # Extract raw bytes from the signature (for QR Code)
-    r, s = signature_asn1.value.map(&:value)
-
-    # Convert r and s to their binary representation and concatenate them to get the raw signature
-    @signature_bytes = [r.to_s(2).rjust(32, "\x00"), s.to_s(2).rjust(32, "\x00")].join
   end
 end

--- a/lib/zatca/signing/ecdsa.rb
+++ b/lib/zatca/signing/ecdsa.rb
@@ -8,8 +8,7 @@ class ZATCA::Signing::ECDSA
 
     {
       base64: ecdsa_signature.toBase64,
-      bytes: ecdsa_signature.toDer,
-      public_key_bytes: private_key.publicKey.toDer
+      bytes: ecdsa_signature.toDer
     }
   end
 

--- a/lib/zatca/tag.rb
+++ b/lib/zatca/tag.rb
@@ -7,9 +7,9 @@ module ZATCA
       invoice_total: 4,
       vat_total: 5,
       xml_invoice_hash: 6,
-      ecdsa_signature: 7,
-      ecdsa_public_key: 8,
-      ecdsa_stamp_signature: 9
+      ecdsa_public_key: 7,
+      ecdsa_signature: 8,
+      ecdsa_stamp_signature: 9 # TODO: is this needed ?
     }.freeze
 
     PHASE_1_TAGS = [

--- a/lib/zatca/tag.rb
+++ b/lib/zatca/tag.rb
@@ -7,8 +7,8 @@ module ZATCA
       invoice_total: 4,
       vat_total: 5,
       xml_invoice_hash: 6,
-      ecdsa_public_key: 7,
-      ecdsa_signature: 8,
+      ecdsa_signature: 7,
+      ecdsa_public_key: 8,
       ecdsa_stamp_signature: 9 # TODO: is this needed ?
     }.freeze
 

--- a/lib/zatca/ubl/invoice.rb
+++ b/lib/zatca/ubl/invoice.rb
@@ -212,10 +212,7 @@ class ZATCA::UBL::Invoice < ZATCA::UBL::BaseComponent
     # @public_key_bytes = parsed_certificate.public_key_bytes
 
     # Current Version
-    @certificate_signature = parsed_certificate.signature_bytes
-
-    # GPT4 Version
-    # @certificate_signature = parsed_certificate.signature_bytes
+    @certificate_signature = parsed_certificate.signature
 
     # Hash signed properties
     signed_properties = ZATCA::UBL::Signing::SignedProperties.new(

--- a/lib/zatca/ubl/invoice.rb
+++ b/lib/zatca/ubl/invoice.rb
@@ -205,11 +205,10 @@ class ZATCA::UBL::Invoice < ZATCA::UBL::BaseComponent
 
     @signed_hash = signature[:base64]
     @signed_hash_bytes = signature[:bytes]
-    @public_key_bytes = signature[:public_key_bytes]
 
     # Parse and hash the certificate
     parsed_certificate = ZATCA::Signing::Certificate.read_certificate(certificate_path)
-    # @public_key_bytes = parsed_certificate.public_key_bytes
+    @public_key_bytes = parsed_certificate.public_key_bytes
 
     # Current Version
     @certificate_signature = parsed_certificate.signature

--- a/spec/lib/zatca/tag_spec.rb
+++ b/spec/lib/zatca/tag_spec.rb
@@ -27,12 +27,12 @@ describe ZATCA::Tag do
       expect(ZATCA::Tag.new(key: :xml_invoice_hash, value: "").id).to eq(6)
     end
 
-    it "gets mapped from ecdsa_public_key to 8" do
-      expect(ZATCA::Tag.new(key: :ecdsa_public_key, value: "").id).to eq(7)
-    end
-    
     it "gets mapped from ecdsa_signature to 7" do
-      expect(ZATCA::Tag.new(key: :ecdsa_signature, value: "").id).to eq(8)
+      expect(ZATCA::Tag.new(key: :ecdsa_signature, value: "").id).to eq(7)
+    end
+
+    it "gets mapped from ecdsa_public_key to 8" do
+      expect(ZATCA::Tag.new(key: :ecdsa_public_key, value: "").id).to eq(8)
     end
 
     it "gets mapped from ecdsa_stamp_signature to 9" do

--- a/spec/lib/zatca/tag_spec.rb
+++ b/spec/lib/zatca/tag_spec.rb
@@ -27,12 +27,12 @@ describe ZATCA::Tag do
       expect(ZATCA::Tag.new(key: :xml_invoice_hash, value: "").id).to eq(6)
     end
 
-    it "gets mapped from ecdsa_signature to 7" do
-      expect(ZATCA::Tag.new(key: :ecdsa_signature, value: "").id).to eq(7)
-    end
-
     it "gets mapped from ecdsa_public_key to 8" do
-      expect(ZATCA::Tag.new(key: :ecdsa_public_key, value: "").id).to eq(8)
+      expect(ZATCA::Tag.new(key: :ecdsa_public_key, value: "").id).to eq(7)
+    end
+    
+    it "gets mapped from ecdsa_signature to 7" do
+      expect(ZATCA::Tag.new(key: :ecdsa_signature, value: "").id).to eq(8)
     end
 
     it "gets mapped from ecdsa_stamp_signature to 9" do

--- a/spec/lib/zatca/ubl/invoice_spec.rb
+++ b/spec/lib/zatca/ubl/invoice_spec.rb
@@ -29,6 +29,7 @@ describe ZATCA::UBL::Invoice do
       # Sign the invoice
       private_key_path = private_key_fixtures_path("private_key.pem")
       certificate_path = certificate_path("certificate.pem")
+      invoice_timestamp = "#{invoice.issue_date}T#{invoice.issue_time}Z"
       signing_time = "2022-09-15T00:41:21Z"
 
       invoice.sign(
@@ -42,7 +43,7 @@ describe ZATCA::UBL::Invoice do
       tags = ZATCA::Tags.new({
         seller_name: "Acme Widgets LTD",
         vat_registration_number: "311111111101113",
-        timestamp: "2022-08-17T17:41:08Z",
+        timestamp: invoice_timestamp,
         vat_total: "30.15",
         invoice_total: "231.15",
         xml_invoice_hash: invoice_hash[:hexdigest_base64],


### PR DESCRIPTION
This is a fix for extracting `public_key` and `signature` from the signing certificates.
Also switches the order of TLV tags in the QR making the certificate signature bytes be the 8th tag instead of 7th.

ZATCA docs are confusing and mention that the tag should be 7 in one page and 8 in another.
However, from testing this with [zatca-xml-js](https://github.com/wes4m/zatca-xml-js) this order along with how the values are extracted is generating a valid signed invoice that passes compliance checks.

- [x] Fix broken QR tests