### PR TITLE
Handle HTTPX:ErrorResponses and add Logging

### DIFF
--- a/lib/zatca/version.rb
+++ b/lib/zatca/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ZATCA
-  VERSION = "1.0.1"
+  VERSION = "1.0.2"
 end


### PR DESCRIPTION
- Add a new `verbose` option to ZATCA::Client that logs requests and responses when `true`, defaulted to `false`.
- When there is an API error, parse HTTPX::ErrorResponse into a hash and return it.