### PR TITLE
Fix Parsing of HTTPX::ErrorResponse and Add Hooks for Advanced Logging

### DIFF
--- a/lib/zatca/version.rb
+++ b/lib/zatca/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ZATCA
-  VERSION = "1.0.2"
+  VERSION = "1.1.0"
 end


### PR DESCRIPTION
There are usecases when users of the SDK need to perform custom logic before the request is sent or response is parsed, so they can add context to exception monitoring platforms.

This change also adds the following two hooks:
- `Client#before_submitting_request`
- `Client#before_parsing_response`

These hooks can be used like so:

```rb
client = ZATCA::Client.new(username: "user", password: "pass", verbose: true)

client.before_submitting_request = proc do |method, url, body, headers|
  # method is a symbol
  # url is a string
  # body and headers are hashes
end

client.before_parsing_response = proc do |response|
  # Response is an instance of HTTPX::Response or HTTPX::ErrorResponse
end
```